### PR TITLE
ユーザ登録の詳細を仮置きするindex作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  def index
+  end
   def new
   end
 end

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,0 +1,58 @@
+= @example
+.iz_wrapper
+  -# 1
+  .iz_header
+    -# 2
+    .iz_h1
+      .iz_a{:href => "https://www.mercari.com/jp/"}
+        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3296506464"}
+  .iz_main
+    -# 2
+    .iz_container
+      -# 3
+      .iz_h2
+        新規会員登録
+      .iz_registration-form
+        -# 4
+        .iz_registration-list
+          -# 5
+          .iz_registration-list__mailaddress
+            -# 6
+            .iz_registration-list__mailaddress__button
+              -# 7
+              = fa_icon "envelope"
+            .iz_registration-list__mailaddress__message{:href => "https://www.mercari.com/jp/signup/registration/"}
+              メールアドレスで登録
+          .iz_registration-list__facebook
+            -# 6
+            .iz_registration-list__facebook__button
+              -# 7
+              = fa_icon "envelope"
+            .iz_registration-list__facebook__message
+              Facebookで登録
+          .iz_registration-list__google
+            -# 6
+            .iz_registration-list__google__button
+              -# 7
+              = fa_icon "envelope"
+            .iz_registration-list__google__message
+              Googleで登録
+    .iz_login_form_facebook
+      -# 3
+    .iz_login_form_google
+      -# 3
+  .iz_footer
+    -# 2
+    .iz_navi
+      -# 3
+      .iz_ul
+        .iz_privacy
+          プライバシーポリシー
+        .iz_tos
+          メルカリ利用規約
+        .iz_tokutei
+          特定商取引に関する表記
+    .iz_a{:href => "https://www.mercari.com/jp/"}
+      %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?3296506464"}
+    .iz_p
+      © 2019 Mercari


### PR DESCRIPTION
#what
ユーザ詳細情報を仮にindexに作成する。

#why
サーバサイドの設定を後に回すため。