### PR TITLE
ヘッダー、フッター、出品ボタンの挿入

### DIFF
--- a/app/assets/stylesheets/item/item_show.scss
+++ b/app/assets/stylesheets/item/item_show.scss
@@ -1,8 +1,8 @@
 .hi-container{
   width: 100%;
-  &__header{
-    height: 100px;  //水谷さんの部分テンプレートできたら指定を外す
-  }
+  // &__header{
+  //   height: 100px;  //水谷さんの部分テンプレートできたら指定を外す
+  // }
   &__content{
     background-color: #f5f5f5;
     @include middle_located();
@@ -125,25 +125,11 @@
           background-color: #ea352d;
           font-weight: bold;
           margin: 0px 16px 0px 0px;
-        }
-        &__tax{
-          margin-top: 40px;
-          font-size: 10px;
-        }
-        &__shipping-fee{
-          margin-top: 34px;
-          font-size: 16px;
-        }
-      }
-      &__buybtn{
-        height: 60px;
-        margin-top: 16px;
-        background-color: #ea352d;
-        font-weight: bold;
-        @include middle_located();
-        &__text{
-          color: white;
-          font-size: 24px;
+          @include middle_located();
+          &__text{
+            color: white;
+            font-size: 24px;
+          }
         }
         &__explanation{
           padding-top: 32px;
@@ -230,8 +216,5 @@
         margin: 0 8px;
       }
     }
-  }
-  &__footer{
-    height: 300px;  //水谷さんの部分テンプレートできたら指定を外す
   }
 }

--- a/app/assets/stylesheets/user/user_edit.scss
+++ b/app/assets/stylesheets/user/user_edit.scss
@@ -1,8 +1,5 @@
 .hi-container{
   width: 100%;
-  &__header{
-    height: 100px;  //水谷さんの部分テンプレートできたら指定を外す
-  }
   &__navigation{
     height: 49px;
     border-top: 1px solid #eee;
@@ -109,8 +106,5 @@
         }
       }
     }
-  }
-  &__footer{
-    height: 100px;  //水谷さんの部分テンプレートできたら指定を外す
   }
 }

--- a/app/views/items/_footer.html.haml
+++ b/app/views/items/_footer.html.haml
@@ -1,6 +1,6 @@
 .m-footerall
   %a1side.app-banner
-    %figure
+    %figure1
       %img.m-app__back{alt: "", src: "https://web-jp-assets.mercdn.net/_next/static/images/download_app_bg-b57d6f1a32f2aebd89cf6f43bc2e4b39.jpg", width: "1000"}/
     .m-app
       
@@ -8,7 +8,7 @@
         %h2.m-app__left__1 スマホでかんたんフリマアプリ
         %p.m-app__left__2 今すぐ無料ダウンロード！
         .m-app__left__icon.clearfix
-          %figure
+          %figure1
             %img.m-app__left__icon__1{alt: "", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/mercari_icon.png?872667783", width: "68"}/
           %ul.m-app__left__icon__smart
             %li.m-app__left__icon__smart__1
@@ -17,7 +17,7 @@
             %li.m-app__left__icon__smart__1
               %a1{href: "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", target: "_blank"}
                 %img{alt: "", height: "40", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/google-play.svg?872667783", width: "133"}/
-      %figure
+      %figure1
         %img.m-app__right{alt: "", src: "//www-mercari-jp.akamaized.net/assets/img/common/jp/download_content_pc.png?872667783", width: "280"}/
   %footer.global-footer
     %nav.m-foot

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,5 @@
 .hi-container
-  .hi-container__header 
-    -# 水谷さん作成の部分テンプレート(ヘッダー)が入る
+  = render 'items/header'
   .hi-container__content
     .hi-container__content__position
       .hi-container__content__position__item
@@ -142,5 +141,5 @@
       = fa_icon "chevron-right", style: 'color: grey'
       %span
         千鳥
-  .hi-container__footer
-    -# 水谷さん作成の部分テンプレート(フッター)が入る
+  = render 'items/sell_btn'
+  = render 'items/footer'

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,6 +1,5 @@
 .hi-container
-  .hi-container__header 
-    -# 水谷さん作成の部分テンプレート(ヘッダー)が入る
+  = render 'items/header'
   .hi-container__navigation
     .hi-container__navigation__text
       %span
@@ -101,5 +100,5 @@
         %textarea{class: "hi-container__main__right__content__textarea", value: "お静かに！"}
         .hi-container__main__right__content__btn
           変更する
-  .hi-container__footer
-    -# 水谷さん作成の部分テンプレート(フッター)が入る
+  = render 'items/sell_btn'
+  = render 'items/footer'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,6 +1,5 @@
 .hi-container
-  .hi-container__header 
-    -# 水谷さん作成の部分テンプレート(ヘッダー)が入る
+  = render 'items/header'
   .hi-container__navigation
     .hi-container__navigation__text
       %span
@@ -163,5 +162,5 @@
         .hi-container__main__right__itemlist__box
           取引中の商品がありません
           .hi-container__main__right__itemlist__box__image
-  .hi-container__footer
-    -# 水谷さん作成の部分テンプレート(フッター)が入る
+  = render 'items/sell_btn'
+  = render 'items/footer'


### PR DESCRIPTION
#what
菱田が作成した商品詳細ページ、ユーザーマイページ、ユーザープロフィール編集ページに水谷さんが作成したヘッダーとフッターと出品ボタンを挿入した。

#why
ヘッダーとフッターと出品ボタンは部分テンプレート化して色々なページで使い回せるようにしたため。