### PR TITLE
itemsテーブル、Itemモデル、Userモデルを修正しました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 |name_first_kana|string|null: false|
 
 ### Association
-- has_many :items
+- has_many :bought_items
+- has_many :saling_items
+- has_many :sold_items
 - has_one :card
 - has_one :address
 
@@ -47,7 +49,6 @@
 ## itemsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user|references|null: false, foreign_key: true|
 |name|string|null: false, index: true|
 |descript|text|null: false|
 |condition|string|null: false|
@@ -56,11 +57,14 @@
 |brand|string||
 |size|string|null: false|
 |category|references|null: false, foreign_key: true|
+|salar_id|integer|null: false, foreign_key: true|
+|buyer_id|integer|foreign_key: true|
 
 ### Association
 - has_many :images
 - has_one :delivery
-- belongs_to :user
+- belongs_to :saler, class_name: "User"
+- belongs_to :buyer, class_name: "User"
 - belongs_to :category
 
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@
 |brand|string||
 |size|string|null: false|
 |category|references|null: false, foreign_key: true|
-|salar_id|integer|null: false, foreign_key: true|
-|buyer_id|integer|foreign_key: true|
+|saler_id|references|null: false, foreign_key: true|
+|buyer_id|references|foreign_key: true|
 
 ### Association
 - has_many :images

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   has_many :images
-  belongs_to :user
-  belongs_to :category
   has_one :delivery
+  belongs_to :category
+  belongs_to :saler, class_name: "User"
+  belongs_to :buyer, class_name: "User"
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,7 @@ class User < ApplicationRecord
 
   has_one :card
   has_one :address
-  has_many :items
+  has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
+  has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Item"
+  has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "saler_id", class_name: "Item"
 end

--- a/db/migrate/20191001044045_change_column_to_items.rb
+++ b/db/migrate/20191001044045_change_column_to_items.rb
@@ -1,7 +1,8 @@
 class ChangeColumnToItems < ActiveRecord::Migration[5.2]
   def change
-    add_column :items, :saler, :references, null: false, foreign_key: true
-    add_column :items, :buyer, :references, foreign_key: true
-    remove_column :items, :user
+    remove_reference :items, :user, foreign_key: true
+
+    add_column :items, :buyer_id, :integer, null: false
+    add_column :items, :seller_id, :integer, null: false
   end
 end

--- a/db/migrate/20191001044045_change_column_to_items.rb
+++ b/db/migrate/20191001044045_change_column_to_items.rb
@@ -1,0 +1,7 @@
+class ChangeColumnToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :saler, :references, null: false, foreign_key: true
+    add_column :items, :buyer, :references, foreign_key: true
+    remove_column :items, :user
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_23_052544) do
+ActiveRecord::Schema.define(version: 2019_10_01_044045) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postal_code", null: false
@@ -57,7 +57,6 @@ ActiveRecord::Schema.define(version: 2019_09_23_052544) do
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.bigint "category_id", null: false
     t.string "name", null: false
     t.text "descript", null: false
@@ -68,9 +67,10 @@ ActiveRecord::Schema.define(version: 2019_09_23_052544) do
     t.string "brand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "buyer_id", null: false
+    t.integer "seller_id", null: false
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["name"], name: "index_items_on_name"
-    t.index ["user_id"], name: "index_items_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -93,5 +93,4 @@ ActiveRecord::Schema.define(version: 2019_09_23_052544) do
 
   add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
-  add_foreign_key "items", "users"
 end


### PR DESCRIPTION
#what
購入機能実装に向けて以下を修正しました。
・itemsテーブルにbuyer_idとseller_idをカラムに追加しました。（外部キーはテーブルがないので、モデルで定義しました。）
・user_idカラムを削除しました。（itemsテーブルにuser_id(外部キー参照)が入らなくなるからもしかしたらまた必要になってくるかも、buyer_idとseller_idにモデルでUserクラスとの結びつきを示すだけで良いのかは謎のまま）

#why
購入機能実装に必要な項目のため。（品物の状況判断）