### PR TITLE
githubからのセキュリティアラートの対応と本番環境のみS3に上がるように分岐を設定しました。

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
-    rubyzip (1.2.4)
+    rubyzip (1.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,9 +4,12 @@ class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   process resize_to_fit: [800, 800]
 
-  # Choose what kind of storage to use for this uploader:
-  storage :fog
-  # storage :fog
+   # 開発／テスト環境ではfileに保存、本番環境ではS3に保存されるようにする。
+  if Rails.env.development? || Rails.env.test? 
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -2,16 +2,21 @@ require 'carrierwave/storage/abstract'
 require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
+#本番環境ではS3にテスト／開発環境ではfile(public/uploads)に保存するよう分岐
 CarrierWave.configure do |config|
-  config.storage = :fog
-  config.fog_provider = 'fog/aws'
-  # config.fog_credentials = {
-  #   provider: 'AWS',
-  #   aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
-  #   aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
-  #   region: 'ap-northeast-1'
-  # }
-
-  config.fog_directory  = 'mercari59'
-  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/mercari59'
+  if Rails.env.production?
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
+      aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
+      region: 'ap-northeast-1'
+    }
+    config.fog_directory  = 'mercari59'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/mercari59'
+  else
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end  
 end


### PR DESCRIPTION
#what
githubからのセキュリティアラートの対応(bundle update rubyzipを実行)
本番環境のみS3に上がるように分岐を設定しました。(image_uploaderとcarrierwaveで条件分岐を書きました。)

#why
・githubからセキュリティアラートが出ていたため。
・master.keyがない私以外の人がS3に保存することができないため。