### PR TITLE
developブランチの修正(masterと同じ状況に)

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,6 +27,7 @@ namespace :deploy do
     task :restart do
       invoke 'unicorn:restart'
     end
+  # master.keyを本番環境のshared/configに置きに行く記述
   #   desc 'upload master.key'
   #   task :upload do
   #     on roles(:app) do |host|


### PR DESCRIPTION
#what
developブランチをmasterと同じ状況に修正しました。
※credentials.yml.enc、master.keyを変更しているので注意

#why
deployできなかったエラーを修正したため。