### PR TITLE
deliveriesテーブルにitem_id(外部キー制約)のカラムを追加しました。

### DIFF
--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,4 +1,4 @@
 class Delivery < ApplicationRecord
   # belongs_to :item
-  has_one :item ,dependent: :destroy
+  belongs_to :item ,dependent: :destroy
 end

--- a/db/migrate/20191007080911_change_column_to_deliveries.rb
+++ b/db/migrate/20191007080911_change_column_to_deliveries.rb
@@ -1,0 +1,7 @@
+class ChangeColumnToDeliveries < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :deliveries, :item, foreign_key: true, null: false
+    # remove_column :deliveries, :item_id, null: false
+    # remove_reference :deliveries, :item, foreign_key: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_02_071756) do
+ActiveRecord::Schema.define(version: 2019_10_07_080911) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postal_code", null: false
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 2019_10_02_071756) do
     t.string "due_time_day", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "item_id", null: false
+    t.index ["item_id"], name: "index_deliveries_on_item_id"
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -92,6 +94,7 @@ ActiveRecord::Schema.define(version: 2019_10_02_071756) do
   end
 
   add_foreign_key "cards", "users"
+  add_foreign_key "deliveries", "items"
   add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
 end


### PR DESCRIPTION
#what
deliveriesテーブルにitem_id(外部キー制約)のカラムを追加しました。

#why
deliveriesテーブルitem_id(外部キー制約)がないと保存したデータが取り出せなくなるため。