### PR TITLE
ログアウト機能の実装

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,9 +14,9 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    super
+  end
 
   # protected
 

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -10,5 +10,5 @@
       .hi-container__wrapper__main__right
         .hi-container__wrapper__main__content
           .hi-container__wrapper__main__content__logout-btn
-            ログアウト
+            = link_to "ログアウト", destroy_user_session_path
   = render 'items/footer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -254,7 +254,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
#what
ログアウトボタンにログアウト機能をもたせる

#why
購入機能確認のためには出品者と購入者でアカウントを使い分ける必要があるため