### PR TITLE
新規登録機能にsession導入【user,address情報のみ】

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,19 +3,19 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:cellphone_number])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name_family])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name_family_kana])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name_first])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name_first_kana])
+  # def configure_permitted_parameters
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:cellphone_number])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:name_family])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:name_family_kana])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:name_first])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:name_first_kana])
 
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:postal_code])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:prefecture])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:city])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:address])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:building])
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:phone_number])
-  end
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:postal_code])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:prefecture])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:city])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:address])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:building])
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:phone_number])
+  # end
 end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,2 +1,70 @@
 class SignupController < ApplicationController
+
+  def step1
+    @user = User.new
+  end
+
+  def step2
+    session[:nickname] = user_params[:nickname]
+    session[:email] = user_params[:email]
+    session[:password] = user_params[:password]
+    session[:name_family] = user_params[:name_family]
+    session[:name_family_kana] = user_params[:name_family_kana]
+    session[:name_first] = user_params[:name_first]
+    session[:name_first_kana] = user_params[:name_first_kana]
+    @user = User.new
+  end
+
+  def step3
+    session[:cellphone_number] = user_params[:cellphone_number]
+    @user = User.new
+    @user.build_address
+  end
+
+  def step4
+    session[:address_attributes] = user_params[:address_attributes]
+    @user = User.new
+  end
+
+def create
+    @user = User.new(
+      nickname: session[:nickname],
+      email: session[:email],
+      password: session[:password],
+      name_family: session[:name_family],
+      name_family_kana:session[:name_family_kana],
+      name_first: session[:name_first],
+      name_first_kana: session[:name_first_kana],
+      cellphone_number: session[:cellphone_number]
+    )
+    @user.build_address(
+      session[:address_attributes]
+    )
+    if @user.save
+      session[:id] = @user.id
+      redirect_to done_signup_index_path
+    else
+      render '/users/new'
+    end
+  end
+
+  def done
+    sign_in User.find(session[:id]) unless user_signed_in?
+  end
+
+    private
+
+  def user_params
+    params.require(:user).permit(
+      :nickname, 
+      :email, 
+      :password, 
+      :cellphone_number, 
+      :name_family, 
+      :name_family_kana, 
+      :name_first, 
+      :name_first_kana, 
+      address_attributes:[:id, :postal_code, :prefecture, :city, :address, :building, :phone_number]
+    )
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,27 +1,28 @@
 # frozen_string_literal: true
 
-class Users::RegistrationsController < Devise::RegistrationsController
+# class Users::RegistrationsController < Devise::RegistrationsController
 
-  def create
-    @user = User.new(user_params)
-    if @user.save
-      sign_in User.find(@user.id)
-      redirect_to root_path, notice: "アカウントを作成しました"
-    else
-      render :new
-    end
-  end
+#   def create
+#     binding.pry
+#     @user = User.new(user_params)
+#     if @user.save
+#       sign_in User.find(@user.id)
+#       redirect_to root_path, notice: "アカウントを作成しました"
+#     else
+#       render :new
+#     end
+#   end
 
-  def new
-    @user = User.new
-    @user.build_address
-  end
+#   def new
+#     @user = User.new
+#     @user.build_address
+#   end
 
-  private
+#   private
 
-  def user_params
-    params.require(:user).permit(:nickname, :email, :password, :cellphone_number, :name_family, :name_family_kana, :name_first, :name_first_kana, address_attributes:[:id, :postal_code, :prefecture, :city, :address, :building, :phone_number])
-  end
+#   def user_params
+#     params.require(:user).permit(:nickname, :email, :password, :cellphone_number, :name_family, :name_family_kana, :name_first, :name_first_kana, address_attributes:[:id, :postal_code, :prefecture, :city, :address, :building, :phone_number])
+#   end
 
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,9 +14,9 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # DELETE /resource/sign_out
-  def destroy
-    super
-  end
+  # def destroy
+  #   super
+  # end
 
   # protected
 

--- a/app/views/signup/step1.html.haml
+++ b/app/views/signup/step1.html.haml
@@ -2,7 +2,7 @@
   .iz2_header
     .iz2_header__progress-bar
       .iz2_header__progress-bar__logo{:href=>"https://www.mercari.com/jp/"}
-        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1383403936"}/
+        = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2296184308"
       .iz2_header__progress-bar__active
         会員情報
         %br

--- a/app/views/signup/step1.html.haml
+++ b/app/views/signup/step1.html.haml
@@ -72,6 +72,6 @@
           .iz2_container__next_button__form-group
             %p.iz2_container__next_button__form-group--text
               「次へ進む」のボタンを押すことにより、
-              %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
+              = link_to  "利用規約", "https://www.mercari.com/jp/tos_list/"
               に同意したものとみなします
         = f.submit 'Send', class: 'iz2_container__next_button--button'

--- a/app/views/signup/step1.html.haml
+++ b/app/views/signup/step1.html.haml
@@ -1,0 +1,77 @@
+.iz2_wrapper
+  .iz2_header
+    .iz2_header__progress-bar
+      .iz2_header__progress-bar__logo{:href=>"https://www.mercari.com/jp/"}
+        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1383403936"}/
+      .iz2_header__progress-bar__active
+        会員情報
+        %br
+        ●
+      .iz2_header__progress-bar__phone-certification
+        電話番号認証
+        %br
+        ●
+      .iz2_header__progress-bar__address
+        お届け先住所入力
+        %br
+        ●
+      .iz2_header__progress-bar__pay
+        支払い方法
+        %br
+        ●
+      .iz2_header__progress-bar__finish
+        完了
+        %br
+        ●
+
+  .iz2_container
+    .iz2_container__header
+      会員情報入力
+    .iz2_container__registration
+      = form_for @user, url: step2_signup_index_path, method: :get do |f|
+        .iz2_container__registration__form-group
+          %label ニックネーム
+          %span.iz2_container__registration__form-group--require 必須
+          = f.text_field :nickname, class: "iz2_container__registration__form-group--input-default", placeholder: "例) メルカリ太郎"
+
+        .iz2_container__registration__form-group
+          %label メールアドレス
+          %span.iz2_container__registration__form-group--require 必須
+          = f.text_field :email, class: "iz2_container__registration__form-group--input-default", placeholder: "PC・携帯どちらでも可"
+
+        .iz2_container__registration__form-group
+          %label パスワード
+          %span.iz2_container__registration__form-group--require 必須
+          = f.text_field :password, class: "iz2_container__registration__form-group--input-default", placeholder: "7文字以上"
+
+        .iz2_container__registration__form-group
+          .iz2_container__registration__form-group--title
+            本人確認
+          .iz2_container__registration__form-group--text
+            安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+
+        .iz2_container__registration__form-group
+          %label お名前(全角)
+          %span.iz2_container__registration__form-group--require 必須
+          = f.text_field :name_family, class: "iz2_container__registration__form-group--input-default", placeholder: "例) 山田"
+          = f.text_field :name_first, class: "iz2_container__registration__form-group--input-default", placeholder: "例) 彩"
+ 
+        .iz2_container__registration__form-group
+          %label お名前カナ(全角)
+          %span.iz2_container__registration__form-group--require 必須
+          = f.text_field :name_family_kana, class: "iz2_container__registration__form-group--input-default", placeholder: "例) ヤマダ"
+          = f.text_field :name_first_kana, class: "iz2_container__registration__form-group--input-default", placeholder: "例) アヤ"
+
+        .iz2_container__registration__form-group__bottom_info
+          ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+
+        .iz2_container__next_button
+          %input{:name => "after_save_callback", :type => "hidden", :value => ""}
+          .iz2_container__next_button__form-group
+            .iz2_g-recaptcha.iz2_signup-recaptcha{"data-sitekey" => "6LfZGCYTAAAAAHoK-s7Lg5OdYg5Fq4susvALmZoc"}
+          .iz2_container__next_button__form-group
+            %p.iz2_container__next_button__form-group--text
+              「次へ進む」のボタンを押すことにより、
+              %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
+              に同意したものとみなします
+        = f.submit 'Send', class: 'iz2_container__next_button--button'

--- a/app/views/signup/step2.html.haml
+++ b/app/views/signup/step2.html.haml
@@ -41,6 +41,6 @@
           .iz2_container__next_button__form-group
             %p.iz2_container__next_button__form-group--text
               「次へ進む」のボタンを押すことにより、
-              %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
+              = link_to  "利用規約", "https://www.mercari.com/jp/tos_list/"
               に同意したものとみなします
         = f.submit 'Send', class: 'iz2_container__next_button--button'

--- a/app/views/signup/step2.html.haml
+++ b/app/views/signup/step2.html.haml
@@ -2,7 +2,7 @@
   .iz2_header
     .iz2_header__progress-bar
       .iz2_header__progress-bar__logo{:href=>"https://www.mercari.com/jp/"}
-        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1383403936"}/
+        = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2296184308"
       .iz2_header__progress-bar__active
         会員情報
         %br

--- a/app/views/signup/step2.html.haml
+++ b/app/views/signup/step2.html.haml
@@ -1,0 +1,46 @@
+.iz2_wrapper
+  .iz2_header
+    .iz2_header__progress-bar
+      .iz2_header__progress-bar__logo{:href=>"https://www.mercari.com/jp/"}
+        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1383403936"}/
+      .iz2_header__progress-bar__active
+        会員情報
+        %br
+        ●
+      .iz2_header__progress-bar__phone-certification
+        電話番号認証
+        %br
+        ●
+      .iz2_header__progress-bar__address
+        お届け先住所入力
+        %br
+        ●
+      .iz2_header__progress-bar__pay
+        支払い方法
+        %br
+        ●
+      .iz2_header__progress-bar__finish
+        完了
+        %br
+        ●
+
+  .iz2_container
+    .iz2_container__header
+      会員情報入力
+    .iz2_container__registration
+      = form_for @user, url: step3_signup_index_path, method: :get do |f|
+        .iz2_container__registration__form-group
+          %label 携帯番号
+          %span.iz2_container__registration__form-group--require 必須
+          = f.text_field :cellphone_number, class: "iz2_container__registration__form-group--input-default", placeholder: "090-1234-5678"
+
+        .iz2_container__next_button
+          %input{:name => "after_save_callback", :type => "hidden", :value => ""}
+          .iz2_container__next_button__form-group
+            .iz2_g-recaptcha.iz2_signup-recaptcha{"data-sitekey" => "6LfZGCYTAAAAAHoK-s7Lg5OdYg5Fq4susvALmZoc"}
+          .iz2_container__next_button__form-group
+            %p.iz2_container__next_button__form-group--text
+              「次へ進む」のボタンを押すことにより、
+              %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
+              に同意したものとみなします
+        = f.submit 'Send', class: 'iz2_container__next_button--button'

--- a/app/views/signup/step3.html.haml
+++ b/app/views/signup/step3.html.haml
@@ -67,6 +67,6 @@
           .iz2_container__next_button__form-group
             %p.iz2_container__next_button__form-group--text
               「次へ進む」のボタンを押すことにより、
-              %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
+              = link_to  "利用規約", "https://www.mercari.com/jp/tos_list/"
               に同意したものとみなします
         = f.submit 'Send', class: 'iz2_container__next_button--button'

--- a/app/views/signup/step3.html.haml
+++ b/app/views/signup/step3.html.haml
@@ -1,0 +1,72 @@
+.iz2_wrapper
+  .iz2_header
+    .iz2_header__progress-bar
+      .iz2_header__progress-bar__logo{:href=>"https://www.mercari.com/jp/"}
+        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1383403936"}/
+      .iz2_header__progress-bar__active
+        会員情報
+        %br
+        ●
+      .iz2_header__progress-bar__phone-certification
+        電話番号認証
+        %br
+        ●
+      .iz2_header__progress-bar__address
+        お届け先住所入力
+        %br
+        ●
+      .iz2_header__progress-bar__pay
+        支払い方法
+        %br
+        ●
+      .iz2_header__progress-bar__finish
+        完了
+        %br
+        ●
+
+  .iz2_container
+    .iz2_container__header
+      会員情報入力
+    .iz2_container__registration
+      = form_for @user, url: step4_signup_index_path, method: :get do |f|
+        = f.fields_for :address do |g|
+          .iz2_container__registration__form-group
+            %label 郵便番号
+            %span.iz2_container__registration__form-group--require 必須
+            = g.text_field :postal_code, class: "iz2_container__registration__form-group--input-default", placeholder: "例) 123-4567"
+
+          .iz2_container__registration__form-group
+            %label 都道府県
+            %span.iz2_container__registration__form-group--require 必須
+            = g.text_field :prefecture, class: "iz2_container__registration__form-group--input-default", placeholder: "例) 神奈川県"
+
+          .iz2_container__registration__form-group
+            %label 市区町村
+            %span.iz2_container__registration__form-group--require 必須
+            = g.text_field :city, class: "iz2_container__registration__form-group--input-default", placeholder: "例) 横浜市緑区"
+
+          .iz2_container__registration__form-group
+            %label 番地
+            %span.iz2_container__registration__form-group--require 必須
+            = g.text_field :address, class: "iz2_container__registration__form-group--input-default", placeholder: "例) 青山1-1-1"
+
+          .iz2_container__registration__form-group
+            %label 建物名
+            %span.iz2_container__registration__form-group--require 任意
+            = g.text_field :building, class: "iz2_container__registration__form-group--input-default", placeholder: "例) 柳ビル103"
+
+          .iz2_container__registration__form-group
+            %label 電話
+            %span.iz2_container__registration__form-group--require 任意
+            = g.text_field :phone_number, class: "iz2_container__registration__form-group--input-default", placeholder: "例) 090-1234-5678"
+
+        .iz2_container__next_button
+          %input{:name => "after_save_callback", :type => "hidden", :value => ""}
+          .iz2_container__next_button__form-group
+            .iz2_g-recaptcha.iz2_signup-recaptcha{"data-sitekey" => "6LfZGCYTAAAAAHoK-s7Lg5OdYg5Fq4susvALmZoc"}
+          .iz2_container__next_button__form-group
+            %p.iz2_container__next_button__form-group--text
+              「次へ進む」のボタンを押すことにより、
+              %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
+              に同意したものとみなします
+        = f.submit 'Send', class: 'iz2_container__next_button--button'

--- a/app/views/signup/step3.html.haml
+++ b/app/views/signup/step3.html.haml
@@ -2,7 +2,7 @@
   .iz2_header
     .iz2_header__progress-bar
       .iz2_header__progress-bar__logo{:href=>"https://www.mercari.com/jp/"}
-        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1383403936"}/
+        = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2296184308"
       .iz2_header__progress-bar__active
         会員情報
         %br

--- a/app/views/signup/step4.html.haml
+++ b/app/views/signup/step4.html.haml
@@ -1,0 +1,46 @@
+.iz2_wrapper
+  .iz2_header
+    .iz2_header__progress-bar
+      .iz2_header__progress-bar__logo{:href=>"https://www.mercari.com/jp/"}
+        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1383403936"}/
+      .iz2_header__progress-bar__active
+        会員情報
+        %br
+        ●
+      .iz2_header__progress-bar__phone-certification
+        電話番号認証
+        %br
+        ●
+      .iz2_header__progress-bar__address
+        お届け先住所入力
+        %br
+        ●
+      .iz2_header__progress-bar__pay
+        支払い方法
+        %br
+        ●
+      .iz2_header__progress-bar__finish
+        完了
+        %br
+        ●
+
+  .iz2_container
+    .iz2_container__header
+      会員情報入力
+    .iz2_container__registration
+      = form_for @user, url: signup_index_path, method: :post do |f|
+        .iz2_container__registration__form-group
+          %label クレジットカード
+          %span.iz2_container__registration__form-group--require 必須
+          -# = f.text_field :nickname, class: "iz2_container__registration__form-group--input-default", placeholder: "例) メルカリ太郎"
+
+        .iz2_container__next_button
+          %input{:name => "after_save_callback", :type => "hidden", :value => ""}
+          .iz2_container__next_button__form-group
+            .iz2_g-recaptcha.iz2_signup-recaptcha{"data-sitekey" => "6LfZGCYTAAAAAHoK-s7Lg5OdYg5Fq4susvALmZoc"}
+          .iz2_container__next_button__form-group
+            %p.iz2_container__next_button__form-group--text
+              「次へ進む」のボタンを押すことにより、
+              %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
+              に同意したものとみなします
+        = f.submit 'Send', class: 'iz2_container__next_button--button'

--- a/app/views/signup/step4.html.haml
+++ b/app/views/signup/step4.html.haml
@@ -41,6 +41,6 @@
           .iz2_container__next_button__form-group
             %p.iz2_container__next_button__form-group--text
               「次へ進む」のボタンを押すことにより、
-              %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
+              = link_to  "利用規約", "https://www.mercari.com/jp/tos_list/"
               に同意したものとみなします
         = f.submit 'Send', class: 'iz2_container__next_button--button'

--- a/app/views/signup/step4.html.haml
+++ b/app/views/signup/step4.html.haml
@@ -2,7 +2,7 @@
   .iz2_header
     .iz2_header__progress-bar
       .iz2_header__progress-bar__logo{:href=>"https://www.mercari.com/jp/"}
-        %img{:src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1383403936"}/
+        = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2296184308"
       .iz2_header__progress-bar__active
         会員情報
         %br

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,15 @@
 Rails.application.routes.draw do
+
+  resources :signup do
+    collection do
+      get "step1"
+      get "step2"
+      get "step3"
+      get "step4"
+      get "done"
+    end
+  end
+
   devise_for :users, :controllers => {
     :registrations => 'users/registrations',
     :sessions => 'users/sessions'   


### PR DESCRIPTION
#what
現状のページ移動無しで登録から、ページ移動ありの登録フォームに変更。
session機能を活用し、動作を最小範囲で確認する。

#why
本家の新規登録がページ移動を伴う登録フォームであるため。
session導入は登録者のレコードが完全な状態でのみ保存するため。

#注釈
クレジットカード情報の登録、バリデーション、view体裁については未実施です。
なおフォーム入力途中でdbに保存されないこと、完了時に保存されることは確認済です。