### PR TITLE
商品詳細の分岐と写真配置を修正しました。

### DIFF
--- a/app/assets/stylesheets/item/item_show.scss
+++ b/app/assets/stylesheets/item/item_show.scss
@@ -63,7 +63,7 @@
                 max-width: 300px;
                 overflow: visible;
                 flex-wrap: wrap;
-                @include both_end_located();
+                display: flex;
                 &__mini{
                   width: 60px;
                   @include middle_located();

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
   accepts_nested_attributes_for :images
 
   def can_purchase
-    if @item.seller_id != current_user
+    if @item.seller_id != current_user.id
       if @item.buyer_id == 0 || @item.buyer_id.blank?
         true
       else

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,7 +7,6 @@
           = @item.name
         .hi-container__content__position__item__detail
           .hi-container__content__position__item__detail__photo
-            -# JSで選択した写真を表示させるコマンドを打ち込む必要あり
             #image-top.hi-container__content__position__item__detail__photo__top
               = image_tag "#{@image[0].image}", class: "top-big-photo"
               - if @item.buyer_id != 0
@@ -105,18 +104,46 @@
             （税込）
           .hi-container__content__position__item__price__shipping-fee
             = @delivery.pay_for_shipping
-        - if @can_purchase == true
-          = link_to "/items/purchase/#{@item.id}", class: "hi-container__content__position__item__buybtn" do
-            .hi-container__content__position__item__buybtn__text
-              購入画面に進む
-        - elsif @can_purchase == false
-          .hi-container__content__position__item__soldbtn
-            .hi-container__content__position__item__soldbtn__text
-              売り切れました
+        - if user_signed_in?
+          - if @can_purchase == true
+            = link_to "/items/purchase/#{@item.id}", class: "hi-container__content__position__item__buybtn" do
+              .hi-container__content__position__item__buybtn__text
+                購入画面に進む
+          - elsif @can_purchase == false
+            .hi-container__content__position__item__soldbtn
+              .hi-container__content__position__item__soldbtn__text
+                売り切れました
+        - else
+          - if @item.buyer_id == 0 || @item.buyer_id.blank?
+            = link_to new_user_session_path, class: "hi-container__content__position__item__buybtn" do
+              .hi-container__content__position__item__buybtn__text
+                購入画面に進む
+          - else
+            .hi-container__content__position__item__soldbtn
+              .hi-container__content__position__item__soldbtn__text
+                売り切れました
         .hi-container__content__position__item__explanation
           .hi-container__content__position__item__explanation__inner
             = @item.descript
-        - if @item.seller_id != current_user.id
+        - if user_signed_in?
+          - if @item.seller_id != current_user.id
+            .hi-container__content__position__item__smallbtns
+              .hi-container__content__position__item__smallbtns__left
+                .hi-container__content__position__item__smallbtns__left__favo
+                  = fa_icon "heart",type: :regular
+                  %span
+                    いいね
+                  %span
+                    0
+                .hi-container__content__position__item__smallbtns__left__ban
+                  = fa_icon "flag",type: :regular
+                  %span
+                    不適切な商品の報告
+              .hi-container__content__position__item__smallbtns__right
+                = fa_icon "key"
+                %span
+                  あんしん・あんぜんへの取り組み
+        - else
           .hi-container__content__position__item__smallbtns
             .hi-container__content__position__item__smallbtns__left
               .hi-container__content__position__item__smallbtns__left__favo
@@ -133,11 +160,12 @@
               = fa_icon "key"
               %span
                 あんしん・あんぜんへの取り組み
-      - if @item.seller_id == current_user.id
-        .hi-container__content__position__btns
-          .hi-container__content__position__btns__edit
-            = link_to  edit_item_path , class: "hi-container__content__position__btns__edit"  do
-              商品の編集
+      - if user_signed_in?
+        - if @item.seller_id == current_user.id
+          .hi-container__content__position__btns
+            .hi-container__content__position__btns__edit
+              = link_to  edit_item_path , class: "hi-container__content__position__btns__edit"  do
+                商品の編集
         
           .hi-container__content__position__btns__text
             or


### PR DESCRIPTION
#what
商品詳細の分岐と写真配置を修正しました。

#why
・ログインしていないユーザーが商品詳細を開くとエラーが出ていたため。
・写真が5枚/行 未満の時写真同士の間に空白を作って配置されていたのを修正するため。