### PR TITLE
エラー解消 card保存前にuserを保存

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -44,20 +44,23 @@ class SignupController < ApplicationController
       session[:address_attributes]
     )
 
-    Payjp.api_key = Rails.application.credentials.dig(:payjp,:PAYJP_SECRET_KEY)
-    customer = Payjp::Customer.create(card: params[:payjpToken])
-    @card = Card.new(user_id: @user.id, customer_id: customer.id, card_id: params[:payjpToken])
-    if @card.save
-      if @user.save
-        session[:id] = @user.id
+    if @user.save
+      session[:id] = @user.id
+
+      Payjp.api_key = Rails.application.credentials.dig(:payjp,:PAYJP_SECRET_KEY)
+      customer = Payjp::Customer.create(card: params[:payjpToken])
+      @card = Card.new(user_id: @user.id, customer_id: customer.id, card_id: params[:payjpToken])
+
+      if @card.save
         redirect_to done_signup_index_path
       else
-        card = Card.where(user_id: @user.id)
-        card.destroy
-        render '/users/new'
+        user = User.find(@user.id)
+        user.destroy
+        render '/signup/step4'
       end
+
     else
-      render '/signup/step4'
+      render '/users/new'
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_one :card
-  has_one :address
+  has_one :address, dependent: :destroy
   accepts_nested_attributes_for :address
   has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
   has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Item"


### PR DESCRIPTION
#what
修正前ではcard保存時にuser.idが取得できていなかったため、cardより先にuserを保存し、card保存に失敗した場合はuserのレコードを削除する。

#why
cardテーブルにuser.idが保存されるようにするため。