### PR TITLE
電話番号のバリデーション強化

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,6 @@ class User < ApplicationRecord
   validates :password, length: {minimum: 7, maximum: 128}
 
   #STEP2入力項目validation
-  validates :cellphone_number, uniqueness: true
+  validates :cellphone_number, uniqueness: true, format: {with: /\A[0-9]{3}-[0-9]{4}-[0-9]{4}\z/}
 
 end


### PR DESCRIPTION
#what
電話番号のバリデーションを半角数字、ハイフン有り、3桁4桁4桁とする

#why
smsを受信するため携帯電話番号である必要があるため