### PR TITLE
本番環境の時のみベーシック認証が発火するようにしました。

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
   protected
 


### PR DESCRIPTION
#what
本番環境の時のみベーシック認証が発火するようにしました。

#why
開発やテスト環境でも発火していたため。